### PR TITLE
Select fieldError propogation

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -38,7 +38,7 @@ export default class Select extends React.Component {
         return classNames(
             'select-wrapper',
             {
-                error: this.props.fieldErrors.length,
+                error: (this.props.fieldErrors || []).length,
                 disabled: this.props.disabled,
                 [`${this.props.className}`]: this.props.className
             }
@@ -68,6 +68,5 @@ Select.propTypes = {
 
 Select.defaultProps = {
     options: [],
-    fieldErrors: [],
     onChange: identity
 }


### PR DESCRIPTION
:bug: :wrench: 

Form clone ignores fieldErrors if the component has it's own fieldErrors (probably should merge or do something better).

For now this ensures that select can receive relevant errors from the Form. 