### PR TITLE
Allow parent to manage value of Select

### DIFF
--- a/src/select.js
+++ b/src/select.js
@@ -12,6 +12,14 @@ export default class Select extends React.Component {
         };
     }
 
+    componentWillReceiveProps(nextProps) {
+        if (nextProps && nextProps.value) {
+            this.setState({
+                value: nextProps.value
+            });
+        }
+    }
+
     /**
      * Handle internal value change before continuing externally.
      *


### PR DESCRIPTION
The use case here is when a Form decided to change a Selects value without that Select's onChange firing.